### PR TITLE
API version updates support for AzureStack

### DIFF
--- a/ARM.psm1
+++ b/ARM.psm1
@@ -280,7 +280,7 @@ function Connect-ARM ($ARMAPIVersion="2015-01-01", $GraphAPIVersion="1.6", $ARMU
   }
 }
 
-function Execute-ARMQuery ($HTTPVerb, $SubscriptionId=$global:ARMDefaultSubscriptionID, $Base, $Query, $Data, $APIVersion=$global:ARMAPIVersion, [switch] $Silent) {
+function Execute-ARMQuery ($HTTPVerb="GET", $SubscriptionId=$global:ARMDefaultSubscriptionID, $Base, $Query, $Data, $APIVersion=$global:ARMAPIVersion, [switch] $Silent) {
   $return = $null
   if($global:ARMTenantAccessTokensARM -ne $null) {
     $header = "Bearer " + $global:ARMTenantAccessTokensARM[$global:ARMSubscriptions[$SubscriptionId].TenantId]


### PR DESCRIPTION
In Connect-ARM
Added a parameter to specify the ARM Endpoint (default Azure as you had it)
Query the metadata on the ARM endpoint to get the right audience identifier 
Updated default API versions for ARM and Graph to latest
Set a global variable for default subscription ID (the 1st one returned)

In Execute-ARMQuery
Set default value for HTTP Verb to GET
Set default value for SubscriptionID to global variable
